### PR TITLE
add instructions to js file

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -21,6 +21,31 @@ var scriptEnvironment = "";
 // limitations under the License.
 
 
+
+
+// =====================================
+// How to install ai2html
+// =====================================
+
+// - Move the ai2html.js file into the Illustrator folder where scripts are located. 
+// - For example, on Mac OS X running Adobe Illustrator CC 2014, the path would be: // Adobe Illustrator CC 2014/Presets/en_US/Scripts/ai2html.jsx
+
+// =====================================
+// How to use ai2html
+// =====================================
+
+// - Create your Illustrator artwork.
+// - Size the artboard to the dimensions that you want the div to appear on the web page.
+// - Make sure your Document Color Mode is set to RGB.
+// - Make sure your document is saved.
+// - Use Arial or Georgia unless you have added your own fonts to the fonts array in the script.
+// - Run the script by choosing: File > Scripts > ai2html
+// - Go to the folder containing your Illustrator file. Inside will be a folder called ai2html-output. 
+// - Open the html files in your browser to preview your output.
+
+
+
+
 // =====================================
 // functions
 // =====================================


### PR DESCRIPTION
Small thing, to be sure, but having the basic instruction inside the js file itself made it a lot easier to refer to them when getting set up. 