### PR TITLE
Make image_output_path independent of html_output_path

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1665,7 +1665,7 @@ if (doc.documentColorSpace!="DocumentColorSpace.RGB") {
 				};
 			};
 
-			var imageDestinationFolder = docPath + docSettings.html_output_path + docSettings.image_output_path;
+			var imageDestinationFolder = docPath + docSettings.image_output_path;
 			checkForOutputFolder(imageDestinationFolder, "image_output_path");
 			var imageDestination = imageDestinationFolder + docArtboardName;
 			// alert ("imageDestination\n" +


### PR DESCRIPTION
Otherwise, if you're outputting HTML files into nested folders, confusing ../../.. acrobatics are required to put the images where you want them.
