### PR TITLE
Numeric sort has to be explicit

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1254,7 +1254,7 @@ if (doc.documentColorSpace!="DocumentColorSpace.RGB") {
 				if (uniqueArtboardWidths.indexOf(abW) < 0) uniqueArtboardWidths.push(abW);
 			}
 		}
-		uniqueArtboardWidths.sort();
+		uniqueArtboardWidths.sort(function(a,b){return a-b;});
 	}
 
 	// begin main stuff


### PR DESCRIPTION
Otherwise messes up the data-min-width and data-max-width attributes for non-NYT script environments when artboards aren't already naturally ordered by size