### PR TITLE
Show completion dialog by default

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -2261,7 +2261,7 @@ if (feedback.length > 0) {
 
 pBar.close();
 
-if (docSettings.show_completion_dialog_box=="true") {
+if (docSettings.show_completion_dialog_box=="true" || docSettings.show_completion_dialog_box=="yes") {
 	alert(alertHed + "\n" + alertText + "\n\n\n================\nai2html-nyt5 v"+scriptVersion);
 };
 


### PR DESCRIPTION
It looks as though that's the intent. There's some confusion between "yes" and "true"; I kept "true" meaning "yes" for backwards compatibility with .ai files that are set to "true"