### PR TITLE
Fix template dropping text containing "$"

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -360,8 +360,8 @@ var applyTemplate = function(template,atObject) {
 		var mustachePattern = new RegExp("\\{\\{\\{? *" + atKey + " *\\}\\}\\}?","g");
 		var ejsPattern      = new RegExp("\\<\\%[=]? *" + atKey + " *\\%\\>","g");
 		var replacePattern  = atObject[atKey];
-		newText = newText.replace( mustachePattern , replacePattern );
-		newText = newText.replace( ejsPattern      , replacePattern );
+		newText = newText.replace( mustachePattern , function(match) { return replacePattern; });
+		newText = newText.replace( ejsPattern      , function(match) { return replacePattern; });
 	};
 	return newText;
 };


### PR DESCRIPTION
Addresses #43

`String.replace`'s second parameter, the replacement string, uses `$` as a special character for submatches of RegExp patterns. Per MDN's [documentation on `replace`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace):

> "The replacement string can include the following special replacement patterns...`$n` Where n is a non-negative integer lesser than 100, inserts the nth parenthesized submatch string, provided the first argument was a RegExp object."

By specifying a function (anonymous or otherwise) as the second parameter, we separate out submatches as function parameters and thus avoid the need for using `$$` instead of `$` in templates.