### PR TITLE
Allow class name compilation on the basis of character styles (applied in Illustrator)

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1761,8 +1761,10 @@ if (doc.documentColorSpace!="DocumentColorSpace.RGB") {
 					thisFrameId = makeKeyword(thisFrame.name);
 				};
 				html[6] += "\t\t\t<div id='"+thisFrameId;
-				html[6] += "' class='"+nameSpace+frameLayer+" "+nameSpace+"aiAbs"+
-					(textIsTransformed(thisFrame) && kind == "point" ? ' g-aiPtransformed' : '')+"' style='";
+				var classNames = docSettings.characterstyles_to_classnames != 'yes' ? nameSpace + frameLayer + ' ' : '';
+				classNames += nameSpace + "aiAbs";
+				classNames += textIsTransformed(thisFrame) && kind == "point" ? ' ' + nameSpace + 'aiPtransformed' : '';
+				html[6] += "' class='" + classNames + "' style='";
 
 				// check if text is transformed
 				if (textIsTransformed(thisFrame)) {

--- a/ai2html.js
+++ b/ai2html.js
@@ -1662,6 +1662,9 @@ if (doc.documentColorSpace!="DocumentColorSpace.RGB") {
 			html[2] += pStyleCss;
 
 			html[2] += '\t\t\t.g-aiPtransformed p { white-space: nowrap; }\r';
+			if (docSettings.characterstyles_to_classnames == 'yes') {
+				html[2] = "";
+			}
 
 			// Output html for each text frame
 			pBar.setTitle(docArtboardName + ': Writing HTML for text blocks...');
@@ -1863,6 +1866,47 @@ if (doc.documentColorSpace!="DocumentColorSpace.RGB") {
 				var numChars = thisFrame.characters.length;
 				var runningChars = 0;
 				for (var k=0;k<thisFrame.paragraphs.length;k++) {
+
+					if (docSettings.characterstyles_to_classnames == 'yes' && runningChars<numChars && thisFrame.paragraphs[k].characters.length!=0) {
+						var sampleChar = Math.round(thisFrame.paragraphs[k].length/2)-1;
+						
+						// if a character style is applied, it's name becomes the paragraph tag's class name
+						var character = thisFrame.paragraphs[k].characters[sampleChar];
+						if (character) {
+							var charStyleName = character.characterStyles[0].name;
+							if (charStyleName != '[Normal Character Style]') {
+								
+								//alert(charStyleName)
+
+								// preserve text-align as inline definition
+								if (thisFrame.characters[0].justification=="Justification.LEFT") {
+									alignment = "left";
+								} else if (thisFrame.characters[0].justification=="Justification.RIGHT") {
+									alignment = "right";
+								} else if (thisFrame.characters[0].justification=="Justification.CENTER") {
+									alignment = "center";
+								} else {
+									alignment = "other";
+								};
+
+								html[6] += "\t\t\t\t<p class='"+charStyleName+"' style='text-align:"+alignment+"'>";
+								if (isNaN(thisFrame.paragraphs[k].length)) {
+									html[6] += "&nbsp;";
+								} else {
+									textToClean = thisFrame.paragraphs[k].contents;
+									textToClean = straightenCurlyQuotesInsideAngleBrackets(textToClean);
+									cleanedText = cleanText(textToClean);
+									html[6] += cleanedText;
+								};
+								html[6] += "</p>\r";
+								runningChars += (thisFrame.paragraphs[k].characters.length)+1;
+								continue;
+							}
+						} else {
+							html[6] += "\t\t\t\t<p>&nbsp;</p>\r";
+							runningChars += 1;
+						};
+					}
 
 					if (runningChars<numChars && thisFrame.paragraphs[k].characters.length!=0) {
 						// var sampleChar = thisFrame.paragraphs[k].length-1;

--- a/ai2html.js
+++ b/ai2html.js
@@ -523,7 +523,8 @@ if (scriptEnvironment=="nyt") {
         scoop_asset_id: {defaultValue: "", includeInSettingsBlock: true, includeInConfigFile: true, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
         scoop_username: {defaultValue: "", includeInSettingsBlock: true, includeInConfigFile: true, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
         scoop_slug: {defaultValue: "", includeInSettingsBlock: true, includeInConfigFile: true, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
-        scoop_external_edit_key: {defaultValue: "", includeInSettingsBlock: true, includeInConfigFile: true, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""}
+        scoop_external_edit_key: {defaultValue: "", includeInSettingsBlock: true, includeInConfigFile: true, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
+		characterstyles_to_classnames: {defaultValue: "no", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "yesNo", possibleValues: "", notes: "Set this to “yes” if you want character styles applied in Illustrator to become paragraph class names."}
 	};
 } else {
 	var ai2htmlBaseSettings = {
@@ -575,7 +576,8 @@ if (scriptEnvironment=="nyt") {
         scoop_asset_id: {defaultValue: "", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
         scoop_username: {defaultValue: "", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
         scoop_slug: {defaultValue: "", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
-        scoop_external_edit_key: {defaultValue: "", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""}
+        scoop_external_edit_key: {defaultValue: "", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "text", possibleValues: "", notes: ""},
+		characterstyles_to_classnames: {defaultValue: "no", includeInSettingsBlock: false, includeInConfigFile: false, useQuoteMarksInConfigFile: false, inputType: "yesNo", possibleValues: "", notes: "Set this to “yes” if you want character styles applied in Illustrator to become paragraph class names."}
 	};
 };
 // End of ai2htmlBaseSettings block copied from Google Spreadsheet.


### PR DESCRIPTION
From a perspective of updatability, it makes more sense to use class names referring to "external" style definitions and not being part of the ai2html output. Another benefit doing so is that the HTML output of a ai2html project will generate less CSS code if no more "project specific" paragraph definitions are needed in it.

At the moment, it's already possible to define custom class names for `div`s containing text. Naming a layer that contains text in Illustrator results in a `div` with a class name consisting of the "slugged" parent layer name and prefixed by the `nameSpace` variable. 
However the class names generated for paragraph elements (wrapped into those `div`s) are not customizable. Even if a `div`'s class name is customized, it's hard to access/overwrite paragraph style definitions like `color` or `font-family`. The reason for this are the generated style blocks making usage of selectors like `#g-project-mobile .g-aiPstyle0`.  For that reason, it's nearly impossible to set paragraph style definitions like `color`, `font-family`, `font-size` or `line-height` by custom classes.

In this PR we propose the setting property `characterstyles_to_classnames` that – if set to `yes` – will.. 
- use the character style's exact name as the class name for the corresponding `div` (instead of `nameSpace` + parent layer name)
- prevent the generic class name that's applied to paragraph elements (i.e. `g-aiPstyle0`) 
- additionally apply `text-align` as inline style to the paragraph element (as the only text property not controlled by Character Styles)
- prevent the output of the generic class name definitions inside the `style` tag

Character Styles in Illustrator work really well. As spaces are allowed in Character Style names (which won't get "slugged"), it's also possible set multiple classes per text element, i.e.: `s-font-text s-font-text--strong`
 

