### PR TITLE
Use docName in id so multiple embeds are unique

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1959,7 +1959,7 @@ function convertTextFrames(textFrames, ab) {
   var pgStyles = [];
   var charStyles = [];
   var baseStyle = deriveCssStyles(frameData);
-  var idPrefix = nameSpace + "ai" + getArtboardId(ab) + "-";
+  var idPrefix = nameSpace + "ai-" + docName + "-" + getArtboardId(ab) + "-";
   var abBox = convertAiBounds(ab.artboardRect);
   var divs = map(frameData, function(obj, i) {
     var frame = textFrames[i];
@@ -2491,7 +2491,7 @@ function captureArtboardImage(ab, textFrames, masks, settings) {
 function generateImageHtml(ab, settings) {
   var abName = getArtboardFullName(ab),
       abPos = convertAiBounds(ab.artboardRect),
-      imgId = nameSpace + "ai" + getArtboardId(ab) + "-0",
+      imgId = nameSpace + "ai-" + docName + "-" + getArtboardId(ab) + "-0",
       extension = (settings.image_format[0] || "png").substring(0,3),
       src = settings.image_source_path + abName + "." + extension,
       html;


### PR DESCRIPTION
Currently including multiple ai2html embeds on a single web page causes ids of elements to be duplicated, but they should be unique.

For example, each ai2html embed includes an image `<img id="g-ai0-0" ...>`. The first text element appears as `<div id="g-ai0-1" ...>`.

This PR avoids that issue by including the `docName` (.ai filename) in these ids.

e.g. `<img id="g-ai-filename-0-0" ...>`

Browsers are pretty forgiving on id uniqueness, but this is causing an issue for us in some of our internal tools. :|

Thanks for open sourcing such a useful tool.