### PR TITLE
Add responsive height feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### v0.74.0
+- Add 'use_responsive_height' and 'responsive_height_limit' settings to limit the maximum artboard height based on the height of the window.
 
 ### v0.73.0
 - Add data-name= properties to div symbols if they are named in Illustrator.

--- a/ai2html.js
+++ b/ai2html.js
@@ -3645,13 +3645,16 @@ function getResizerScript(settings) {
     }
 
     function updateGraphic(container) {
-      var artboards = selectElements("." + nameSpace + "artboard[data-min-width]", container),
+      var artboards = selectElements("." + nameSpace + "artboard[data-min-width]", container);
           width = Math.round(container.getBoundingClientRect().width),
           height = Math.round(window.innerHeight),
           id = container.id, // assume container has an id
           showImages = !observer || visibilityIndex[id] == 'visible',
           heightLimit = opts.responsive_height_limit,
           maxHeight = Math.round((heightLimit / 100) * height);
+
+      // Sort from widest to narrowest
+      artboards.sort(function(a, b) { return b.getAttribute("data-min-width") - a.getAttribute("data-min-width")});
 
       // Set artboard visibility
       artboards.some(function(el, i) {
@@ -3783,8 +3786,9 @@ function getResizerScript(settings) {
       };
     }
   };
-  
-  // validate settings for responsive height
+
+  // convert function to JS source code
+  // validate options for responsive height
   if (settings.use_responsive_height == 'yes') {
     var heightLimit = parseFloat(settings.responsive_height_limit) || null; // accepts 90% or 90
     if (heightLimit > 100 || heightLimit < 0) {
@@ -3792,7 +3796,6 @@ function getResizerScript(settings) {
     }
   }
 
-  // convert function to JS source code
   var opts = {
     namespace: nameSpace,
     environment: scriptEnvironment,

--- a/ai2html.js
+++ b/ai2html.js
@@ -3621,6 +3621,7 @@ function convertSettingsToYaml(settings) {
 function getResizerScript(settings) {
   // The resizer function is embedded in the HTML page -- external variables must
   // be passed in.
+
   var resizer = function (opts) {
     var nameSpace = opts.namespace;
     // Use a sentinel class to ensure that this version of the resizer only initializes once
@@ -3649,7 +3650,7 @@ function getResizerScript(settings) {
           height = Math.round(window.innerHeight),
           id = container.id, // assume container has an id
           showImages = !observer || visibilityIndex[id] == 'visible',
-          heightLimit = parseFloat(opts.responsive_height_limit) || null, // accepts 90% or 90
+          heightLimit = opts.responsive_height_limit,
           maxHeight = Math.round((heightLimit / 100) * height);
 
       // Set artboard visibility
@@ -3782,13 +3783,21 @@ function getResizerScript(settings) {
       };
     }
   };
+  
+  // validate settings for responsive height
+  if (settings.use_responsive_height == 'yes') {
+    var heightLimit = parseFloat(settings.responsive_height_limit) || null; // accepts 90% or 90
+    if (heightLimit > 100 || heightLimit < 0) {
+      error('responsive_height_limit must be between 0 and 100.');
+    }
+  }
 
   // convert function to JS source code
   var opts = {
     namespace: nameSpace,
     environment: scriptEnvironment,
     responsiveness: settings.responsiveness,
-    responsive_height_limit: settings.use_responsive_height == 'yes' ? settings.responsive_height_limit : null
+    responsive_height_limit: settings.use_responsive_height == 'yes' ? heightLimit : null
   };
   var resizerJs = '(' +
     trim(resizer.toString().replace(/  /g, '\t')) + // indent with tabs


### PR DESCRIPTION
Adds two settings, `use_responsive_height` and `responsive_height_limit`. If `use_responsive_height` is `yes`, then the height of the artboard will not exceed `responsive_height_limit` percent of the window height. If every artboard exceeds this height, ai2html will display the smallest artboard (by width).

Note that `responsive_height_limit` must be between 0 and 100 inclusive.