### PR TITLE
Adds support for settings in a config.yml located in same directiory.

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1283,6 +1283,11 @@ function initDocumentSettings(textBlockSettings) {
       settings.create_config_file = true;
       settings.create_promo_image = true;
     }
+  } else { // local config.yml file options loader
+    var yaml = readYamlConfigFile(docPath + "config.yml") || {};
+    forEachProperty(yaml, function(v, k){
+      settings[k] = v;
+    });
   }
 
   // merge settings from text block


### PR DESCRIPTION
By including this small addition, the script will look for a file called `config.yml` located in the same directory as the open AI file. The current system already has a system to output settings to such a file with the `includeInConfigFile` setting. 

Settings will now be loaded (in order from least to the most precedence):
- [`defaultBaseSettings`](https://github.com/newsdev/ai2html/blob/master/ai2html.js#L115) / [`nytBaseSettings`](https://github.com/newsdev/ai2html/blob/master/ai2html.js#L59)
- A `config.yml` located in the same directory
- A settings block located inside the AI file (generated by the script)

If no settings block is found inside the AI file, the value created in the block will also follow the same order of precedence (values in `config.yml` will overwrite the base settings).

This isn't a direct fix to #86, but it can potentially help make the script's configuration more robust.