### PR TITLE
Add an alt attribute to artboard image

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3257,7 +3257,7 @@ function generateImageHtml(imgFile, imgId, imgClass, imgStyle, ab, settings) {
     // (<img> element requires a src attribute, according to spec.)
     src = 'data:image/gif;base64,R0lGODlhCgAKAIAAAB8fHwAAACH5BAEAAAAALAAAAAAKAAoAAAIIhI+py+0PYysAOw==';
   }
-  html += ' src="' + src + '"/>\r';
+  html += ' src="' + src + '" alt="" />\r';
   return html;
 }
 


### PR DESCRIPTION
So I'm proposing this because I did a light accessibility audit of NBC News' graphics and this is one of the problems that came up -- ai2html images don't have alt attributes. An empty alt attribute is better than no alt attribute -- without an alt attribute, screen readers read the src attribute aloud to the reader.

Thank you for considering this change.