### PR TITLE
Linting and code styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
     "confirm": true,
     "Folder": true,
     "File": true,
-    "DocumentColorspace": true,
+    "DocumentColorSpace": true,
     "IllustratorSaveOptions": true,
     "ZOrderMethod": true,
     "TextType": true,
@@ -26,12 +26,15 @@
     "ExportOptionsPNG8": true,
     "ExportOptionsPNG24": true,
     "ExportOptionsJPEG": true,
+    "ExportOptionsSVG": true,
     "SVGFontSubsetting": true,
     "SVGDocumentEncoding": true,
     "SVGDTDVersion": true,
     "SVGCSSPropertyLocation": true,
     "SaveOptions": true,
     "Event": true,
-    "$": true
+    "$": true,
+    "it": true,
+    "describe": true
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["eslint:recommended", "plugin:es5/no-es2015"],
+  "rules": {
+    "semi": ["error", "always"],
+    "quotes": ["error", "double"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,37 @@
 {
   "extends": ["eslint:recommended", "plugin:es5/no-es2015"],
+  "env": {
+    "browser": true,
+    "node": true
+},
   "rules": {
     "semi": ["error", "always"],
     "quotes": ["error", "double"]
+  },
+  "globals": {
+    "app": true,
+    "alert": true,
+    "confirm": true,
+    "Folder": true,
+    "File": true,
+    "DocumentColorspace": true,
+    "IllustratorSaveOptions": true,
+    "ZOrderMethod": true,
+    "TextType": true,
+    "Window": true,
+    "BlendModes": true,
+    "ElementPlacement": true,
+    "PointType": true,
+    "ExportType": true,
+    "ExportOptionsPNG8": true,
+    "ExportOptionsPNG24": true,
+    "ExportOptionsJPEG": true,
+    "SVGFontSubsetting": true,
+    "SVGDocumentEncoding": true,
+    "SVGDTDVersion": true,
+    "SVGCSSPropertyLocation": true,
+    "SaveOptions": true,
+    "Event": true,
+    "$": true
   }
 }

--- a/ai2html.js
+++ b/ai2html.js
@@ -32,6 +32,9 @@
 // - Go to the folder containing your Illustrator file. Inside will be a folder called ai2html-output.
 // - Open the html files in your browser to preview your output.
 
+// Globals available from Illustrator
+// https://www.adobe.com/devnet/illustrator/scripting.html
+
 function main() {
 // Enclosing scripts in a named function (and not an anonymous, self-executing
 // function) has been recommended as a way to minimise intermittent "MRAP" errors.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha --check-leaks",
     "prepublishOnly": "./prepublish.sh",
     "lint": "eslint ai2html*.js test/**/*js",
-    "lintFix": "eslint ai2html*.js test/**/*js --fix"
+    "lintFix": "eslint ai2html.js test/**/*js --fix"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "ai2html",
   "version": "0.81.4",
   "description": "A script for Adobe Illustrator that converts your Illustrator artwork into an html page.",
-"main": "./ai2html.js",
-"scripts": {
+  "main": "./ai2html.js",
+  "scripts": {
     "test": "mocha --check-leaks",
-    "prepublishOnly": "./prepublish.sh"
+    "prepublishOnly": "./prepublish.sh",
+    "lint": "eslint ai2html*.js test/**/*js",
+    "lintFix": "eslint ai2html*.js test/**/*js --fix"
   },
   "repository": {
     "type": "git",
@@ -17,6 +19,8 @@
     "url": "https://github.com/newsdev/ai2html/issues"
   },
   "devDependencies": {
+    "eslint": "^5.11.1",
+    "eslint-plugin-es5": "^1.3.1",
     "mocha": ">=3.2.0"
   },
   "homepage": "https://github.com/newsdev/ai2html#readme"


### PR DESCRIPTION
Wonderful project, thanks so much for sharing with the world.

This pull requests adds some linting and code style consistency support, which, for neurotic people like me, makes it easier to contribute.  I think code styles are great, but I don't want to be preachy about it.

This adds two things:

1. [eslint](https://eslint.org/) which will enforce code style while helping to identify errors.
    * Configuration is managed in `.eslintrc.json`.  It builds off the recommended linting from the `eslint` module, and adds just a couple differences that I think align with the current styles.
    * It also adds an `es5` plugin, as I think Illustrator uses an older version of a Javascript engine, but I can't find very definitive documentation about this.
    * Basic checking can be done with `npm run lint`, which will lint the main `ai2html.js` and the JS files in `tests/`.
    * You can also fix in place with `npm run lintFix`.  This will update the files, but will also error, as there are some code that just needs to be updated to pass.
1. [editorconfig](https://editorconfig.org/) which is a low-level configuration around code editors.  The main thing it does that is helpful is define spacing, such as two spaces (vs. tabs).  See below for how this can be very helpful.

## Future considerations

* I did not actually run the fixing and commit it here, since that would be a very noisy commit.
* There are plugins for editors to add integration for these tools.
    * [editorconfig integrations](https://editorconfig.org/#download) actually work seamlessly, where pressing "tab" will insert the correct characters defined in the `.editorconfig` config.
    * [eslint integrations](https://eslint.org/docs/user-guide/integrations) should at least highlight issues as you edit, though many editors may have some sort of "format on save" option which may seem extreme, but I find very helpful.
         * Note that, using `eslint` with [prettier](https://prettier.io/docs/en/editors.html) can be very helpful for other types of files.
* Another option may to add a pre-commit git hook to format when making a commit.
* I didn't add any documentation about this, but would be worth mentioning in a contributors section.

