### PR TITLE
Prevent having multiple layers with name "ai2html-settings"

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1270,6 +1270,10 @@ function initSpecialTextBlocks() {
     if (!type) return; // not a special block
     lines = stringToLines(thisFrame.contents);
     lines.shift(); // remove header
+    // Reset the name of any non-settings text boxes with name ai2html-settings
+    if (type != 'settings' && thisFrame.name == 'ai2html-settings') {
+      thisFrame.name = '';
+    }
     if (type == 'settings' || type == 'text') {
       settings = settings || {};
       if (type == 'settings') {


### PR DESCRIPTION
A coworker copied an `ai2html-settings` text box to create an `ai2html-css` text box, and edited its contents to include css instead of settings. The script injected `cache_bust_token: XX` into his `ai2html-css` block from then on, because the css text box's `name` was also `ai2html-settings`. (The function `updateSettingsEntry` looks up the text boxes by their name, assuming there will be only one with the name `ai2html-settings`.

This tweak prevents that scenario by resetting the name of text boxes that do not contain ai2html settings.