### PR TITLE
Use getBoundingClientRect left/right

### DIFF
--- a/_includes/resizer-script.html
+++ b/_includes/resizer-script.html
@@ -10,7 +10,7 @@
                 widthById = {};
             elements.forEach(function(el) {
                 var parent = el.parentNode,
-                    width = widthById[parent.id] || parent.getBoundingClientRect().width,
+                    width = widthById[parent.id] || (parent.getBoundingClientRect().right - parent.getBoundingClientRect().left),
                     minwidth = el.getAttribute("data-min-width"),
                     maxwidth = el.getAttribute("data-max-width");
                 widthById[parent.id] = width;


### PR DESCRIPTION
MDN reports inconsistent support on mobile for getBoundingClientRect().width, but consistent for getBoundingClientRect().right and getBoundingClientRect.left().

Fixes errors experienced by @superkazi