### PR TITLE
Override responsiveness setting per artboard

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3725,8 +3725,17 @@ function generateArtboardDiv(ab, breakpoints, settings) {
   if (!isFalse(settings.include_resizer_classes)) {
     classnames += " " + findShowClassesForArtboard(ab, breakpoints);
   }
+  // Default to document's responsiveness setting
+  var responsiveness = settings.responsiveness;
+  // If artboard name begins with "f-" (fixed) or "d-" (dynamic), override
+  // responsiveness setting
+  if (/^f-/.test(getArtboardFullName(ab))) {
+    responsiveness = "fixed";
+  } else if (/^d-/.test(getArtboardFullName(ab))) {
+    responsiveness = "dynamic";
+  }
   // Set size of graphic using inline CSS
-  if (settings.responsiveness == "fixed") {
+  if (responsiveness == "fixed") {
     inlineStyle = "width:" + abBox.width + "px; height:" + abBox.height + "px;";
   } else {
     // Adding bottom padding as a percentage of container width to set the artboard

--- a/ai2html.js
+++ b/ai2html.js
@@ -3729,9 +3729,10 @@ function generateArtboardDiv(ab, breakpoints, settings) {
   var responsiveness = settings.responsiveness;
   // If artboard name begins with "f-" (fixed) or "d-" (dynamic), override
   // responsiveness setting
-  if (/^f-/.test(getArtboardFullName(ab))) {
+  var artboardName = getArtboardName(ab);
+  if (/^f-/.test(artboardName)) {
     responsiveness = "fixed";
-  } else if (/^d-/.test(getArtboardFullName(ab))) {
+  } else if (/^d-/.test(artboardName)) {
     responsiveness = "dynamic";
   }
   // Set size of graphic using inline CSS


### PR DESCRIPTION
Hi all,

We've found it useful to be able to override the responsiveness setting for specific artboards. Often we want out smaller widths to flow responsively but not necessarily worry about the responsiveness of gaps between our larger artboards.

This PR allows overriding the responsiveness value of an artboard via the artboard name: Artboard names that begin with `f-` will be rendered in "fixed" mode, and names that begin with `d-` will be rendered in "dynamic" mode. (I wasn't sure if there was another way to specify data on artboards. If you have other ideas I'd love to hear them.)

Thanks as always for open sourcing such a useful tool.