### PR TITLE
Apply centering code to wrapper and artboards

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3829,6 +3829,7 @@ function generatePageCss(containerId, settings) {
     css += t2 + "}\r";
   }
   if (isTrue(settings.center_html_output)) {
+    css += t2 + "#" + containerId + ",\r";
     css += t2 + "#" + containerId + " ." + nameSpace + "artboard {\r";
     css += t3 + "margin:0 auto;\r";
     css += t2 + "}\r";


### PR DESCRIPTION
Fixes #119

Without this code (or another solution) using both settings.max_width
and settings.center_html_output causes the div that wraps all artboards
to have a max-width but no centering code. That results in e.g. a 600px
artboard not being centered when embedded in a space wider than 600px.