### PR TITLE
Use actual width -- not potentially overridden width -- on smallest artboard

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1768,7 +1768,14 @@ function getArtboardWidthRange(ab, settings) {
   var w = getArtboardWidth(ab);
   var visibleRange = getArtboardVisibilityRange(ab, settings);
   if (responsiveness == 'fixed') {
-    return [visibleRange[0] === 0 ? 0 : w, w];
+    if (visibleRange[0] === 0) {
+      // For the smallest artboard, use the actual artboard width, not the
+      // potentially overridden width
+      var actualW = convertAiBounds(ab.artboardRect).width
+      return [0, actualW];
+    } else {
+      return [w, w];
+    }
   }
   return visibleRange;
 }


### PR DESCRIPTION
Fixes a bug with the logic that automatically displays the narrowest
artboard when the graphic is displayed at an even narrower width.

If the smallest artboard's width is say 300px, but the artboard's name
sets its min-width to 280px (using the :MIN_WIDTH artboard name syntax),
the previous logic would set an inline CSS style of max-width to 280px.
This PR fixes that by adjusting the getArtboardWidthRange() function to
-- for the smallest artboard -- set the width range to [0, actualWidth]
rather than the potentially overridden width. Since the actual width of
the artboard in this example is 300px, the inline CSS style becomes
max-width: 300px as expected.

Please let me know if this explanation is unclear, and I can create and
send an example .ai file and the output with and without this bugfix.