### PR TITLE
Add examples to GitHub repository instead of del.icio.us

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ai2html is an open-source script for Adobe Illustrator that converts your Illustrator documents into html and css.
 
-Here are [examples of how we’ve used the script](https://del.icio.us/archietse/ai2html,nyt) at The New York Times and [examples of how others](https://del.icio.us/archietse/ai2html,others) have used it. Share your ai2html projects on Twitter, Delicious, etc. using #ai2html.
+Here are [examples of how we’ve used the script](examples/nyt.md) at The New York Times and [examples of how others](examples/others.md) have used it. Share your ai2html projects on Twitter, Delicious, etc. using #ai2html.
 
 For documentation and examples on [how to use ai2html](http://ai2html.org), please visit [ai2html.org](http://ai2html.org).
 
@@ -21,6 +21,3 @@ If you’re learning to write Javascript for Adobe Illustrator, [John Wundes](ht
 <p style="font-size:.8em;opacity:0.5;">Created by <a href="https://twitter.com/archietse">Archie Tse</a> / <a href="https://github.com/newsdev">The New York Times</a></p>
 
 <p style="font-size:.8em;opacity:0.7;">Copyright (c) 2011-2015 The New York Times Company</p>
-
-
-

--- a/examples/nyt.md
+++ b/examples/nyt.md
@@ -1,0 +1,92 @@
+# Examples of [ai2html](https://ai2html.org) at The New York Times
+
+[Maps of the Disappearance of AirAsia Flight 8501](https://www.nytimes.com/interactive/2014/12/28/world/asia/airasia-flight-qz8501-map.html)
+
+[Severe Drought Grows Worse in California](https://www.nytimes.com/2014/01/18/us/as-californias-drought-deepens-a-sense-of-dread-grows.html)
+
+[A Culture of Bidding: Forging an Art Market in China](https://www.nytimes.com/projects/2013/china-art-fraud/?ref=international-home)
+
+[Mapping the Path of Typhoon Haiyan - Map](https://www.nytimes.com/interactive/2013/11/11/world/asia/typhoon-haiyan-map.html)
+
+[The Greatest President - Graphic](https://www.nytimes.com/interactive/2013/11/10/us/politics/the-greatest-president.html)
+
+[Bill de Blasio’s Circle of Power - Graphic](https://www.nytimes.com/interactive/2013/11/08/nyregion/bill-de-blasios-circle-of-power.html)
+
+[Why Some People Can’t Keep Their Insurance Plans - Graphic](https://www.nytimes.com/interactive/2013/10/30/us/why-some-people-cant-keep-their-insurance-plans.html)
+
+[Inflation Fails - Graphic](https://www.nytimes.com/interactive/2013/10/27/business/economy/inflation-falls.html)
+
+[How Winglets Work - Graphic](https://www.nytimes.com/interactive/2013/10/24/business/Why-Winglets.html)
+
+[A Bubble Bursts - Graphic](https://www.nytimes.com/interactive/2013/10/22/business/a-bubble-bursts.html)
+
+[How HealthCare.gov Was Supposed to Work and How It Didn’t - Graphic](https://www.nytimes.com/interactive/2013/10/13/us/how-the-federal-exchange-is-supposed-to-work-and-how-it-didnt.html)
+
+[The Treasury’s Dwindling Cash Supply](https://www.nytimes.com/interactive/2013/10/10/us/the-treasurys-dwindling-cash-supply.html)
+
+[Opening Week of Health Exchanges - Graphic](https://www.nytimes.com/interactive/2013/10/04/us/opening-week-of-health-exchanges.html)
+
+[The Impact of the 2011 Debt Ceiling Showdown - Graphic](https://www.nytimes.com/interactive/2013/10/03/us/politics/Assessing-the-Impact-of-the-2011-Debt-Ceiling-Showdown.html)
+
+[Where Poor and Uninsured Americans Live - Interactive Map](https://www.nytimes.com/interactive/2013/10/02/us/uninsured-americans-map.html)
+
+[The Republicans Standing Their Ground - Graphic](https://www.nytimes.com/interactive/2013/10/02/us/politics/the-band-of-republicans-standing-their-ground.html)
+
+[The Back and Forth Over the Shutdown - Graphic](https://www.nytimes.com/interactive/2013/09/30/us/politics/the-back-and-forth-over-the-shutdown.html)
+
+[Shopping for Coverage - Graphic](https://www.nytimes.com/interactive/2013/09/29/business/Shopping-for-Coverage.html)
+
+[A History of Fed Appointments - Graphic](https://www.nytimes.com/interactive/2013/09/27/us/politics/federal-reserve-appointments.html)
+
+[A History of Pollution - Map](https://www.nytimes.com/interactive/2013/09/26/nyregion/gowanus-pollution-map.html)
+
+[Women’s Progress Stalls - Graphic](https://www.nytimes.com/interactive/2013/09/25/business/Womens-Progress-Stalls.html)
+
+[What Congress Must Do to Avoid a Shutdown - Graphic](https://www.nytimes.com/interactive/2013/09/24/us/politics/what-congress-must-do-to-avoid-a-shutdown.html)
+
+[The Site of the Washington Navy Yard Shooting - Graphic](https://www.nytimes.com/interactive/2013/09/16/us/site-of-the-navy-yard-shooting.html)
+
+[How the Shooting Near Times Square Unfolded - Graphic](https://www.nytimes.com/interactive/2013/09/15/nyregion/0915-how-the-shooting-unfolded.html)
+
+[How de Blasio Turned Conventional Wisdom on Its Head - Graphic](https://www.nytimes.com/interactive/2013/09/11/nyregion/mayoral-primary-vote-analysis.html)
+
+[Missing Out - Graphic](https://www.nytimes.com/interactive/2013/09/04/business/Missing-Out.html)
+
+[Attempts to Control Contamination by Radioactivity in Fukushima - Graphic](https://www.nytimes.com/interactive/2013/09/03/world/asia/controlling-contamination-in-fukushima.html)
+
+[Two Thriving Dialysis Companies - Graphic](https://www.nytimes.com/interactive/2013/08/29/us/two-thriving-dialysis-companies.html)
+
+[Household Income’s Slow Climb Back - Graphic](https://www.nytimes.com/interactive/2013/08/21/us/household-incomes-slow-climb.html)
+
+[Connected by Country - Map](https://www.nytimes.com/interactive/2013/08/20/business/Connected-by-Country.html)
+
+[Behind the Decision on the Stop-and-Frisk Policy - Graphic](https://www.nytimes.com/interactive/2013/08/12/nyregion/10-years-of-stop-and-frisk.html)
+
+[Helping Housing - Graphic](https://www.nytimes.com/interactive/2013/08/06/business/helping-housing.html)
+
+[The Battle for the Fed - Graphic](https://www.nytimes.com/interactive/2013/07/26/us/the-battle-for-the-fed.html)
+
+[Bloomberg’s Plan to Protect the Coast Focuses on Key Areas - Graphic](https://www.nytimes.com/interactive/2013/06/12/nyregion/bloombergs-plan-to-protect-the-coast-focuses-on-these-areas.html)
+
+[A Shortage of Apartments for Sale - Graphic](https://www.nytimes.com/interactive/2013/02/10/realestate/cover.html)
+
+[Siding With the Liberal Wing - Graphic](https://www.nytimes.com/interactive/2012/06/28/us/supreme-court-liberal-wing-5-4-decisions.html)
+
+[Challenges Facing Leaders in the European Debt Crisis - Graphic](https://www.nytimes.com/interactive/2011/11/02/world/europe/challenges-facing-leaders-in-the-european-debt-crisis.html)
+
+[A New Variation in Boarding an Airplane - Interactive Feature](https://www.nytimes.com/interactive/2011/10/31/business/American-Airlines-new-randomized-seating-method.html)
+
+[The ‘Shadow’ Republican Party - Graphic](https://www.nytimes.com/interactive/2011/10/29/us/politics/the-shadow-republican-party.html)
+
+[Three Steps Forward in Containing the Debt Crisis - Graphic](https://www.nytimes.com/interactive/2011/10/28/business/three-steps-forward-in-containing-the-debt-crisis.html)
+
+[Changes in Black Voter Turnout - Graphic](https://www.nytimes.com/interactive/2011/10/27/us/politics/changes-in-black-voter-turnout.html)
+
+[Americans’ Approval of Congress Drops to Single Digits - Interactive Feature](https://www.nytimes.com/interactive/2011/10/25/us/politics/approval-of-congress-drops-to-single-digits.html)
+
+[Banks Are Swimming in Cash - Graphic](https://www.nytimes.com/interactive/2011/10/25/business/banks-are-swimming-in-cash.html)
+
+[Assessing the Redistricting Outlook - Graphic](https://www.nytimes.com/interactive/2011/10/18/us/assessing-the-redistricting-outlook.html)
+
+[The Northeast Passage Opens Up - Map](https://www.nytimes.com/interactive/2011/10/18/business/the-northeast-passage-opens-up.html)
+

--- a/examples/others.md
+++ b/examples/others.md
@@ -1,0 +1,98 @@
+# Examples of [ai2html](https://ai2html.org)
+
+[The mile-long site where a truck hit hundreds in Nice, France](https://www.washingtonpost.com/graphics/world/bastille-day-truck-attack-nice-france/)
+
+[Juno peeks behind Jupiter’s clouds - Los Angeles Times](https://www.latimes.com/projects/la-sci-juno-jupiter-mission/)
+
+[How the Dallas protest shootings unfolded | US news | The Guardian](https://www.theguardian.com/us-news/ng-interactive/2016/jul/08/how-the-dallas-protest-shootings-unfolded-police)
+
+[What we know about the attack on police in Dallas - Washington Post](https://www.washingtonpost.com/graphics/national/dallas-protest-shooting/)
+
+[Road closures, schedules and how to get to D.C. on the Fourth of July - Washington Post](https://www.washingtonpost.com/graphics/local/july-4-2016-closures/)
+
+[Europe’s many alliances, reimagined as a metro system - Washington Post](https://www.washingtonpost.com/graphics/world/how-european-countries-are-bound-together/)
+
+[Tesla’s Betting You’ll Pay $9,000 for a Software Upgrade](https://www.bloomberg.com/graphics/2016-tesla-model-s/)
+
+[The Great Asian Arms Buildup: China's Military Expansion, South China Sea to dominate Shangri-La Dialogue](https://www.bloomberg.com/graphics/2016-shangrila/)
+
+[What we know about the Orlando nightclub mass shooting - Washington Post](https://www.washingtonpost.com/graphics/national/orlando-shooting/)
+
+[How the Orlando Shooting Unfolded - WSJ.com](https://graphics.wsj.com/orlando-shooting/)
+
+[Wayback Machine home page](https://www.washingtonpost.com/graphics/politics/2016-election/primaries/super-tuesday-virginia-analysis/)
+
+[Chicago's snowfall is average this season - Chicago Tribune](https://www.chicagotribune.com/news/weather/ct-chicago-winter-amount-snowfall-htmlstory.html)
+
+[Why minority voters matter for Democrats in Nevada and beyond - Washington Post](https://www.washingtonpost.com/graphics/politics/2016-election/primaries/nevada-democratic-analysis/)
+
+[These charts are good news for Trump if he really does win South Carolina - Washington Post](https://www.washingtonpost.com/graphics/politics/2016-election/primaries/south-carolina-gop-analysis/)
+
+[Plant your seeds at the perfect time using this gardener-approved guide - The Washington Post](https://www.washingtonpost.com/apps/g/page/lifestyle/plant-your-seeds-at-the-perfect-time-using-this-gardener-approved-guide/1950/)
+
+[How Trump and Sanders Broadened Their Bases in New Hampshire - WSJ.com](https://graphics.wsj.com/elections/2016/new-hampshire-demographics-base/)
+
+[Graphics: What Trump's and Sanders's wins in New Hampshire mean for the rest of the race - Washington Post](https://www.washingtonpost.com/graphics/politics/2016-election/primaries/new-hampshire-results-analysis/)
+
+[The Many Faces of Iowa’s Caucus Voters - WSJ.com](https://graphics.wsj.com/elections/2016/iowa-caucuses-demographics/)
+
+[How extreme cold can damage a body - The Washington Post](https://www.washingtonpost.com/apps/g/page/national/how-extreme-cold-can-damage-a-body/1936/)
+
+[In maps: Iraqi soldiers retook the government compound in central Ramadi from Islamic State on Monday - WSJ.com](https://graphics.wsj.com/battle-for-ramadi-dec-28/)
+
+[Wayback Machine home page](https://www.chicagotribune.com/sports/breaking/ct-navy-pier-americas-cup-if-you-go-htmlstory.html%3Futm_content%3Dbuffer53611%26utm_medium%3Dsocial%26utm_source%3Dtwitter.com%26utm_campaign%3Dbuffer)
+
+[Music Festivals Have A Glaring Woman Problem. Here’s Why.](https://data.huffingtonpost.com/music-festivals)
+
+[Fische halten ist schwer: Der Ozean im Wohnzimmer - NZZ Lebensart: Gesellschaft](https://www.nzz.ch/lebensart/gesellschaft/fische-halten-ist-schwer-der-ozean-im-wohnzimmer-ld.8356)
+
+[Tokyo Olympics: €1.3m payment to secret account raises questions over 2020 Games | Sport | The Guardian](www.theguardian.com/sport/2016/may/11/tokyo-olympics-payment-diack-2020-games)
+
+[How Malaysia's 1MDB Fund Scandal Reaches Around the World](https://www.bloomberg.com/graphics/2016-malaysia-1mdb/)
+
+[What's that)
+
+[Brussels Suicide Bomber Slipped Terror Net](https://www.wsj.com/articles/brussels-suicide-bomber-slipped-terror-net-1458779556)
+
+[Chicago's boring winter, told in 6 boring charts](https://www.chicagotribune.com/news/local/breaking/ct-boring-winter-weather-htmlstory.html)
+
+[Rivalries Stall Push to Retake Iraqi City - WSJ](https://www.wsj.com/articles/rivalries-stall-push-to-retake-iraqi-city-1457311742)
+
+[How one economic decision in Flint caused a health crisis - Washington Post](https://www.washingtonpost.com/graphics/health/flint-water-crisis/)
+
+[Wayback Machine home page](https://www.washingtonpost.com/graphics/lifestyle/the-evolution-of-the-national-mall/)
+
+[Zika Virus: Aerial spraying to fight mosquitoes winning only half the battle | Miami Herald](https://www.miamiherald.com/news/health-care/article95838697.html)
+
+[China’s Growing Debt Problem Isn’t Quite What It Seems](https://www.bloomberg.com/graphics/2016-china-debt/)
+
+[Tropical wave weakens but still threatening South Florida, hurricane forecasters say | Miami Herald](https://www.miamiherald.com/news/weather/hurricane/article97760862.html)
+
+[The history of the National Mall, from the White House to the National Museum of African American History and Culture - Washington Post](https://www.washingtonpost.com/graphics/lifestyle/the-evolution-of-the-national-mall/)
+
+[Zika virus: Latest STD worry for millennials, same-sex couples | Miami Herald](https://www.miamiherald.com/news/health-care/article95330072.html)
+
+[The Carving Out of the Urban Middle Class - WSJ.com](https://graphics.wsj.com/urban-income-polarization/%3Fmod%3De2twg)
+
+[Rio 2016 visualized: The Olympics in charts and graphics - Washington Post](https://www.washingtonpost.com/graphics/sports/olympics/olympics-collection/when-women-started-participating-in-the-olympics.html)
+
+[De geboorte van een Olympisch Park](https://multimedia.tijd.be/rio/)
+
+[The Bank of Japan’s Stimulus Decision Comes to an Economy in Trouble](https://www.bloomberg.com/graphics/2016-japan-economy/)
+
+[Wayback Machine home page](https://www.theguardian.com/world/2015/apr/20/two-more-mediterranean-migrant-boats-issue-distress-calls-as-eu-ministers-meet)
+
+[Personal delivery - The Washington Post](https://apps.washingtonpost.com/g/page/local/personal-delivery/1669/)
+
+[Delta Smelt, Icon of California Water Wars, Is Almost Extinct](https://news.nationalgeographic.com/2015/04/150403-smelt-california-bay-delta-extinction-endangered-species-drought-fish/)
+
+[Explainer: What the Iran nuclear agreement could mean - LA Times](https://www.latimes.com/visuals/graphics/la-fg-g-iran-nuclear-explainer-20150327-htmlstory.html)
+
+[How the lock function of the Germanwing Airbus 320 cockpit works - LA Times](https://www.latimes.com/la-fg-g-cockpit-procedures-20150326-htmlstory.html)
+
+[Path of Germanwings flight 4U9525 | World news | The Guardian](https://www.theguardian.com/world/ng-interactive/2015/mar/24/path-of-germanwings-flight-4u9525-interactive)
+
+[Breaking Down the Breakdown: How RSL conceded from a throw-in - RSL Soapbox](https://www.rslsoapbox.com/2015/3/17/8228971/breaking-down-the-breakdown-how-rsl-conceded-from-a-throw-in)
+
+[Live, Up in the Sky! | Chicago magazine](https://www.chicagomag.com/Chicago-Magazine/April-2015/chicago-real-estate/residential-skyscrapers/)
+

--- a/examples/others.md
+++ b/examples/others.md
@@ -1,10 +1,10 @@
 # Examples of [ai2html](https://ai2html.org)
 
-[The mile-long site where a truck hit hundreds in Nice, France](https://www.washingtonpost.com/graphics/world/bastille-day-truck-attack-nice-france/)
+[The mile-long site where a truck hit hundreds in Nice, France - Washington Post](https://www.washingtonpost.com/graphics/world/bastille-day-truck-attack-nice-france/)
 
 [Juno peeks behind Jupiter’s clouds - Los Angeles Times](https://www.latimes.com/projects/la-sci-juno-jupiter-mission/)
 
-[How the Dallas protest shootings unfolded | US news | The Guardian](https://www.theguardian.com/us-news/ng-interactive/2016/jul/08/how-the-dallas-protest-shootings-unfolded-police)
+[How the Dallas protest shootings unfolded - The Guardian](https://www.theguardian.com/us-news/ng-interactive/2016/jul/08/how-the-dallas-protest-shootings-unfolded-police)
 
 [What we know about the attack on police in Dallas - Washington Post](https://www.washingtonpost.com/graphics/national/dallas-protest-shooting/)
 
@@ -12,15 +12,13 @@
 
 [Europe’s many alliances, reimagined as a metro system - Washington Post](https://www.washingtonpost.com/graphics/world/how-european-countries-are-bound-together/)
 
-[Tesla’s Betting You’ll Pay $9,000 for a Software Upgrade](https://www.bloomberg.com/graphics/2016-tesla-model-s/)
+[Tesla’s Betting You’ll Pay $9,000 for a Software Upgrade - Bloomber](https://www.bloomberg.com/graphics/2016-tesla-model-s/)
 
-[The Great Asian Arms Buildup: China's Military Expansion, South China Sea to dominate Shangri-La Dialogue](https://www.bloomberg.com/graphics/2016-shangrila/)
+[The Great Asian Arms Buildup: China's Military Expansion, South China Sea to dominate Shangri-La Dialogue - Bloomberg](https://www.bloomberg.com/graphics/2016-shangrila/)
 
 [What we know about the Orlando nightclub mass shooting - Washington Post](https://www.washingtonpost.com/graphics/national/orlando-shooting/)
 
 [How the Orlando Shooting Unfolded - WSJ.com](https://graphics.wsj.com/orlando-shooting/)
-
-[Wayback Machine home page](https://www.washingtonpost.com/graphics/politics/2016-election/primaries/super-tuesday-virginia-analysis/)
 
 [Chicago's snowfall is average this season - Chicago Tribune](https://www.chicagotribune.com/news/weather/ct-chicago-winter-amount-snowfall-htmlstory.html)
 
@@ -40,27 +38,25 @@
 
 [In maps: Iraqi soldiers retook the government compound in central Ramadi from Islamic State on Monday - WSJ.com](https://graphics.wsj.com/battle-for-ramadi-dec-28/)
 
-[Wayback Machine home page](https://www.chicagotribune.com/sports/breaking/ct-navy-pier-americas-cup-if-you-go-htmlstory.html%3Futm_content%3Dbuffer53611%26utm_medium%3Dsocial%26utm_source%3Dtwitter.com%26utm_campaign%3Dbuffer)
+[Guide to America's Cup sailboat race at Navy Pier - Chicago Tribune](https://www.chicagotribune.com/sports/breaking/ct-navy-pier-americas-cup-if-you-go-htmlstory.html)
 
-[Music Festivals Have A Glaring Woman Problem. Here’s Why.](https://data.huffingtonpost.com/music-festivals)
+[Music Festivals Have A Glaring Woman Problem. Here’s Why. - Huffington Post](https://data.huffingtonpost.com/music-festivals)
 
 [Fische halten ist schwer: Der Ozean im Wohnzimmer - NZZ Lebensart: Gesellschaft](https://www.nzz.ch/lebensart/gesellschaft/fische-halten-ist-schwer-der-ozean-im-wohnzimmer-ld.8356)
 
-[Tokyo Olympics: €1.3m payment to secret account raises questions over 2020 Games | Sport | The Guardian](www.theguardian.com/sport/2016/may/11/tokyo-olympics-payment-diack-2020-games)
+[Tokyo Olympics: €1.3m payment to secret account raises questions over 2020 Games - The Guardian](www.theguardian.com/sport/2016/may/11/tokyo-olympics-payment-diack-2020-games)
 
-[How Malaysia's 1MDB Fund Scandal Reaches Around the World](https://www.bloomberg.com/graphics/2016-malaysia-1mdb/)
+[How Malaysia's 1MDB Fund Scandal Reaches Around the World - Bloomberg](https://www.bloomberg.com/graphics/2016-malaysia-1mdb/)
 
-[What's that)
+[Brussels Suicide Bomber Slipped Terror Net - Wall Street Journal](https://www.wsj.com/articles/brussels-suicide-bomber-slipped-terror-net-1458779556)
 
-[Brussels Suicide Bomber Slipped Terror Net](https://www.wsj.com/articles/brussels-suicide-bomber-slipped-terror-net-1458779556)
+[Chicago's boring winter, told in 6 boring charts - Chicago Tribune](https://www.chicagotribune.com/news/local/breaking/ct-boring-winter-weather-htmlstory.html)
 
-[Chicago's boring winter, told in 6 boring charts](https://www.chicagotribune.com/news/local/breaking/ct-boring-winter-weather-htmlstory.html)
-
-[Rivalries Stall Push to Retake Iraqi City - WSJ](https://www.wsj.com/articles/rivalries-stall-push-to-retake-iraqi-city-1457311742)
+[Rivalries Stall Push to Retake Iraqi City - Wall Street Journal](https://www.wsj.com/articles/rivalries-stall-push-to-retake-iraqi-city-1457311742)
 
 [How one economic decision in Flint caused a health crisis - Washington Post](https://www.washingtonpost.com/graphics/health/flint-water-crisis/)
 
-[Wayback Machine home page](https://www.washingtonpost.com/graphics/lifestyle/the-evolution-of-the-national-mall/)
+[The history of the National Mall, from the White House to the National Museum of African American History and Culture - Washington Post](https://www.washingtonpost.com/graphics/lifestyle/the-evolution-of-the-national-mall/)
 
 [Zika Virus: Aerial spraying to fight mosquitoes winning only half the battle | Miami Herald](https://www.miamiherald.com/news/health-care/article95838697.html)
 
@@ -80,9 +76,7 @@
 
 [The Bank of Japan’s Stimulus Decision Comes to an Economy in Trouble](https://www.bloomberg.com/graphics/2016-japan-economy/)
 
-[Wayback Machine home page](https://www.theguardian.com/world/2015/apr/20/two-more-mediterranean-migrant-boats-issue-distress-calls-as-eu-ministers-meet)
-
-[Personal delivery - The Washington Post](https://apps.washingtonpost.com/g/page/local/personal-delivery/1669/)
+[Two more migrant boats issue distress calls in Mediterranean - The Guardian](https://www.theguardian.com/world/2015/apr/20/two-more-mediterranean-migrant-boats-issue-distress-calls-as-eu-ministers-meet)
 
 [Delta Smelt, Icon of California Water Wars, Is Almost Extinct](https://news.nationalgeographic.com/2015/04/150403-smelt-california-bay-delta-extinction-endangered-species-drought-fish/)
 
@@ -90,9 +84,9 @@
 
 [How the lock function of the Germanwing Airbus 320 cockpit works - LA Times](https://www.latimes.com/la-fg-g-cockpit-procedures-20150326-htmlstory.html)
 
-[Path of Germanwings flight 4U9525 | World news | The Guardian](https://www.theguardian.com/world/ng-interactive/2015/mar/24/path-of-germanwings-flight-4u9525-interactive)
+[Path of Germanwings flight 4U9525 - The Guardian](https://www.theguardian.com/world/ng-interactive/2015/mar/24/path-of-germanwings-flight-4u9525-interactive)
 
 [Breaking Down the Breakdown: How RSL conceded from a throw-in - RSL Soapbox](https://www.rslsoapbox.com/2015/3/17/8228971/breaking-down-the-breakdown-how-rsl-conceded-from-a-throw-in)
 
-[Live, Up in the Sky! | Chicago magazine](https://www.chicagomag.com/Chicago-Magazine/April-2015/chicago-real-estate/residential-skyscrapers/)
+[Live, Up in the Sky! - Chicago Magazine](https://www.chicagomag.com/Chicago-Magazine/April-2015/chicago-real-estate/residential-skyscrapers/)
 

--- a/examples/others.md
+++ b/examples/others.md
@@ -68,8 +68,6 @@
 
 [Zika virus: Latest STD worry for millennials, same-sex couples | Miami Herald](https://www.miamiherald.com/news/health-care/article95330072.html)
 
-[The Carving Out of the Urban Middle Class - WSJ.com](https://graphics.wsj.com/urban-income-polarization/%3Fmod%3De2twg)
-
 [Rio 2016 visualized: The Olympics in charts and graphics - Washington Post](https://www.washingtonpost.com/graphics/sports/olympics/olympics-collection/when-women-started-participating-in-the-olympics.html)
 
 [De geboorte van een Olympisch Park](https://multimedia.tijd.be/rio/)


### PR DESCRIPTION
The del.icio.us links of examples in the README were broken, so I pulled some some of these pages from archive.org and added them to an examples directory. I updated the README to point to these instead of del.icio.us.