### PR TITLE
Update default nyt page template to dolos

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -165,7 +165,7 @@ var nytOverrideSettings = {
   "use_lazy_loader": true,
   "include_resizer_script": true,
   "credit": "By The New York Times",
-  "page_template": "vi-article-embed",
+  "page_template": "dolos-vi-article-embed",
   "publish_system": "scoop",
 
   // NYT-specific settings (not present in default settings)


### PR DESCRIPTION
Sets the default page template to use the new NYT previewing backend. 