### PR TITLE
Option to disable writing settings block

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -88,6 +88,7 @@ var defaultSettings = {
   "render_text_as": "html", // Options: html, image
   "render_rotated_skewed_text_as": "html", // Options: html, image
   "testing_mode": false,  // Render text in both bg image and HTML to test HTML text placement
+  "write_settings_block": true, //Add settings block to ai file
   "show_completion_dialog_box": true,
   "clickable_link": "",  // Add a URL to make the entire graphic a clickable link
   "last_updated_text": "",
@@ -493,7 +494,7 @@ try {
 
   nameSpace = docSettings.namespace || nameSpace;
 
-  if (!textBlockData.settings) {
+  if (!textBlockData.settings && docSettings.write_settings_block) {
     createSettingsBlock(docSettings);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "ai2html",
-  "version": "0.111.0",
+  "version": "0.115.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "ai2html",
-      "version": "0.111.0",
+      "version": "0.115.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "mocha": "^10.0.0"


### PR DESCRIPTION
Added boolean config setting `write_settings_block` to allow the skipping of adding a settings block to the illustrator document. This is a useful feature when automating ai2html, since `ai2html-config.json` becomes the single source of truth for settings.

This was the problem I was encountering:

I run ai2html with an automation script. When I ran my script with a fresh new AI file, my automation script would use settings from `ai2html-config.json`. But subsequent runs would ignore changes to that file in favor of the settings blocks now located in the AI file.

With this change, settings are always sourced from `ai2html-config.json`, no matter the number of times I run my automation script.
