### PR TITLE
In NYT override settings, change NYTMagSans font-face name to nyt-magsans

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -344,8 +344,8 @@ var nytOverrideSettings = {
     {"aifont":"StymieBT-ExtraBold","family":"nyt-stymie,arial,helvetica,sans-serif","weight":"700","style":""},
     {"aifont":"Stymie-Thin","family":"nyt-stymie,arial,helvetica,sans-serif","weight":"300","style":""},
     {"aifont":"Stymie-UltraLight","family":"nyt-stymie,arial,helvetica,sans-serif","weight":"300","style":""},
-    {"aifont":"NYTMagSans-Regular","family":"'nyt-mag-sans',arial,helvetica,sans-serif","weight":"500","style":""},
-    {"aifont":"NYTMagSans-Bold","family":"'nyt-mag-sans',arial,helvetica,sans-serif","weight":"700","style":""}
+    {"aifont":"NYTMagSans-Regular","family":"'nyt-magsans',arial,helvetica,sans-serif","weight":"500","style":""},
+    {"aifont":"NYTMagSans-Bold","family":"'nyt-magsans',arial,helvetica,sans-serif","weight":"700","style":""}
   ]
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai2html",
-  "version": "0.115.2",
+  "version": "0.115.3",
   "description": "A script for Adobe Illustrator that converts your Illustrator artwork into an html page.",
   "main": "./ai2html.js",
   "scripts": {


### PR DESCRIPTION
To match the commonly used web font-face declaration, according to @jmyint 