### PR TITLE
Add support for font-stretch property

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -429,6 +429,7 @@ var cssTextStyleProperties = [
   'font-size',
   'font-weight',
   'font-style',
+  'font-stretch',
   'color',
   'line-height',
   'height', // used for point-type paragraph styles
@@ -2758,6 +2759,9 @@ function convertAiTextStyle(aiStyle) {
     }
     if (fontInfo.style) {
       cssStyle['font-style'] = fontInfo.style;
+    }
+    if (fontInfo.stretch) {
+      cssStyle['font-stretch'] = fontInfo.stretch;
     }
   }
   if ('leading' in aiStyle) {


### PR DESCRIPTION
Adds support for adding a `stretch` property in the config file, to set the `font-stretch` CSS attribute ([See MDN docs here](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch)). 

We needed this change in order to support the condensed and semicondensed versions of our variable font, and I thought others might find this useful as well.