### PR TITLE
set default aria-role as img, use sr-only text as aria-describedby

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -177,7 +177,7 @@ var nytBirdkitEmbedSettings = {
   "create_json_config_files": true,
   "create_promo_image": false,
   "credit": "By The New York Times",
-  "aria_role": "figure",
+  "aria_role": "img",
   "alt_text": "",
   "page_template": "vi-article-embed",
   "display_for_promotion_only": false,
@@ -230,7 +230,7 @@ var nytPreviewEmbedSettings = {
   "config_file_path": "../config.yml",
   "create_promo_image": true,
   "credit": "By The New York Times",
-  "aria_role": "figure",
+  "aria_role": "img",
   "alt_text": "",
   "publish_system": "scoop",
   "page_template": "vi-article-embed",
@@ -4596,10 +4596,10 @@ function generateOutputHtml(content, pageName, settings) {
   }
 
   // HTML
-  html = '<div id="' + containerId + '" class="' + containerClasses + '"' + ariaAttrs + '>\r';
+  html = '<div id="' + containerId + '" class="' + containerClasses + '"' + ariaAttrs + ' aria-describedby="' + containerId + '-img-desc">\r';
 
   if (settings.alt_text) {
-    html += '<div class="' + nameSpace + 'aiAltText">' +
+    html += '<div class="' + nameSpace + 'aiAltText" id="' + containerId + '-img-desc">' +
       encodeHtmlEntities(settings.alt_text) + '</div>';
   }
   if (linkSrc) {

--- a/ai2html.js
+++ b/ai2html.js
@@ -4567,6 +4567,7 @@ function generateOutputHtml(content, pageName, settings) {
   var linkSrc = settings.clickable_link || '';
   var responsiveJs = '';
   var containerId = nameSpace + makeDocumentSlug(pageName) + '-box';
+  var altTextId = containerId + '-img-desc';
   var textForFile, html, js, css, commentBlock;
   var htmlFileDestinationFolder, htmlFileDestination;
   var containerClasses = 'ai2html';
@@ -4574,7 +4575,10 @@ function generateOutputHtml(content, pageName, settings) {
   // accessibility features
   var ariaAttrs = '';
   if (settings.aria_role) {
-    ariaAttrs = ' role="' + settings.aria_role + '"';
+    ariaAttrs += ' role="' + settings.aria_role + '"';
+  }
+  if (settings.alt_text) {
+    ariaAttrs += ' aria-describedby="' + altTextId + '"';
   }
 
   progressBar.setTitle('Writing HTML output...');
@@ -4596,10 +4600,10 @@ function generateOutputHtml(content, pageName, settings) {
   }
 
   // HTML
-  html = '<div id="' + containerId + '" class="' + containerClasses + '"' + ariaAttrs + ' aria-describedby="' + containerId + '-img-desc">\r';
+  html = '<div id="' + containerId + '" class="' + containerClasses + '"' + ariaAttrs + '>\r';
 
   if (settings.alt_text) {
-    html += '<div class="' + nameSpace + 'aiAltText" id="' + containerId + '-img-desc">' +
+    html += '<div class="' + nameSpace + 'aiAltText" id="' + altTextId + '">' +
       encodeHtmlEntities(settings.alt_text) + '</div>';
   }
   if (linkSrc) {


### PR DESCRIPTION
Hi Matt, 

After looking at a few embeds yesterday, I thought the changes I propose in this PR might improve the screen reader experience. They are: 
- make the default aria-role an `img` rather than a `figure` (as a reminder a figure will let you access all of the text inside the graphic, and more often than not it's better to treat it as a flat img, though users can change that if they'd like.
- add an `id` to our visually hidden text, and use that to give the same element with the `role` a description - right now if folks use `aria-role="img"`, they won't actually get to the visually hidden text. this approach will also make it more discoverable when folks click on the graphic area with their mouse while using a screen reader