### PR TITLE
Locked ai file layers don't re-lock after running script

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -2195,6 +2195,7 @@ function unlockObject(obj) {
   if (obj && obj.typename != "Document") {
     unlockObject(obj.parent);
     obj.locked = false;
+    objectsToRelock.push(obj);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai2html",
-  "version": "0.115.4",
+  "version": "0.120.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ai2html",
-      "version": "0.115.4",
+      "version": "0.120.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "mocha": "^10.0.0"


### PR DESCRIPTION
The ai2html.js script has two definitions of a function named `unlockObject`.  The [first](https://github.com/newsdev/ai2html/blob/master/ai2html.js#L1270) adds to the `objectsToRelock` array, the [second](https://github.com/newsdev/ai2html/blob/master/ai2html.js#L2193) (which likely overwrites the first) does not.

Adding `objectsToRelock.push(obj);` to the second function results in the desired effect of re-locking ai file layers.