### PR TITLE
fix project_name parameter bug

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -672,7 +672,7 @@ function render(settings, customBlocks) {
     }
     artboardContent.css += generateArtboardCss(activeArtboard, abStyles, settings);
 
-    var oname = settings.output == 'one-file' ? getRawDocumentName() : docArtboardName;
+    var oname = settings.output == 'one-file' ? docSlug : docArtboardName;
     // kludge to identify legacy embed projects
     if (settings.output == 'one-file' &&
         settings.project_type == 'ai2html' &&


### PR DESCRIPTION
Possible fix for #166. Now when you have a `project_name` param, your artboard images AND your html file all have a name that reflects the `project_name` param. If no param is indicated, it still defaults back to the illustrator file name, as intended. 

Worth noting that `output: multiple-files` already prints out filenames that match the `project_name` parameter. This change brings `output: one-file` settings in line with that and with previous versions. 

If the current setup (always using `getRawDocumentName()` for `one-file` projects) is intended behavior, feel free to close this PR. 