### PR TITLE
In using `:video`, removes the requirement that URL must start with https

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3559,7 +3559,7 @@ function convertSpecialLayers(activeArtboard, settings) {
 
 function makeVideoHtml(url, settings) {
   url = trim(url);
-  if (!/^https:/.test(url) || !/\.mp4$/.test(url)) {
+  if (!/\.mp4$/.test(url)) {
     return '';
   }
   var srcName = isTrue(settings.use_lazy_loader) ? 'data-src' : 'src';


### PR DESCRIPTION
(redoing https://github.com/newsdev/ai2html/pull/179 because i had to make a separate PR/suggestion!)

* Could be useful for videos hosted at a relative URL or for URL rewriting (let's say you're on staging and want to point to a video on staging server; then switch to live seamlessly)

* I could also see a case where the `.mp4` check could be removed but that seems like most people will support at least mp4 and can rewrite it if they're in an environment that allows JS