### PR TITLE
slugify the box (group container) ID too

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1944,7 +1944,7 @@ function getRawDocumentName() {
 }
 
 function getGroupContainerId(groupName) {
-  return nameSpace + groupName + '-box';
+  return nameSpace + makeKeyword(groupName.replace(/ +/g,"-")) + '-box';
 }
 
 // Prevent duplicate artboard names by appending width


### PR DESCRIPTION
* If ai2html is used on an Illustrator file name containing invalid element ID characters (anything not alphanumeric/hyphen/underscore), then the group container's ID breaks down.

Currently, if you run ai2html on a file with spaces and other non-alphanumeric/hyphen/underscore characters:

<img width="622" height="452" alt="Capture d’écran, le 2025-09-09 à 10 45 47" src="https://github.com/user-attachments/assets/f6ded0cd-0406-48f6-95ef-07c14d73369c" />

The fix would escape these invalid characters, like it does on the IDs and class names of img, div elements in the HTML output:

<img width="665" height="478" alt="Capture d’écran, le 2025-09-09 à 10 45 25" src="https://github.com/user-attachments/assets/3a952aef-95e5-47cc-84fa-85f7bd11a590" />

* Intrigued that aside from the top "tktk-box" container ID, all the other IDs on images, text elements, etc., seem properly escaped! I dug a bit, but not exhaustively as to why/where the escape functions were being applied...