### PR TITLE
fix : Doesn't get groups correctly  in groupArtboardsForOutput

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1363,7 +1363,7 @@ function groupArtboardsForOutput(settings) {
       // multiple-file output: artboards are grouped by name
       groupName = getDocumentArtboardName(ab);
       group = find(groups, function(o) {
-        o.name == groupName;
+        return o.groupName == groupName;
       });
     }
     if (!group) {


### PR DESCRIPTION

Currently when multiple artboards share the same name while having different artboard sizes, artboard sizes are not merged into resulting html file correctly, even when 'multiple-files' is on.  


<img width="897" height="225" alt="Screenshot 2025-09-23 at 11 29 56 AM" src="https://github.com/user-attachments/assets/0f601d61-77b2-4f79-8c41-df8a401eaabd" />
-
