### PR TITLE
multiple `:video` layers will all get added to the html

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3549,11 +3549,12 @@ function convertSpecialLayers(activeArtboard, settings) {
     if (objectIsHidden(lyr)) return;
     var str = getSpecialLayerText(lyr, activeArtboard);
     if (!str) return;
-    var html = makeVideoHtml(str, settings);
+    var name = lyr.name.replace(/:.*/, '')
+    var html = makeVideoHtml(str, settings, name);
     if (!html) {
       warn('Invalid video URL: ' + str);
     } else {
-      data.video = html;
+      data.video += html;
     }
     data.layers.push(lyr);
   });
@@ -3574,13 +3575,13 @@ function convertSpecialLayers(activeArtboard, settings) {
   return data.layers.length === 0 ? null : data;
 }
 
-function makeVideoHtml(url, settings) {
+function makeVideoHtml(url, settings, name) {
   url = trim(url);
   if (!/^https:/.test(url) || !/\.mp4$/.test(url)) {
     return '';
   }
   var srcName = isTrue(settings.use_lazy_loader) ? 'data-src' : 'src';
-  return '<video ' + srcName + '="' + url + '" autoplay muted loop playsinline style="top:0; width:100%; object-fit:contain; position:absolute"></video>';
+  return '<video class="g-' + name +'" ' + srcName + '="' + url + '" autoplay muted loop playsinline style="top:0; width:100%; object-fit:contain; position:absolute"></video>';
 }
 
 function getSpecialLayerText(lyr, ab) {


### PR DESCRIPTION
Instead of only embedding one video, if you want multiple videos to be placed on the page you can do so by adding additional layers that have `:video`. At this time, it doesn't allow for multiple URLs in the same layer. 

Layer name is added as a class to each video for selection/targeting in the browser. 

One caveat is that `0.123.3` currently seems to not be correctly lazy-loading video at all, regardless of this change 🙃 . `0.123.1` works fine though.