### PR TITLE
Fix: Relock locked groups/layers

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -1460,6 +1460,15 @@ function initSpecialTextBlocks() {
       // An error will be thrown if trying to hide a text frame inside a
       // locked layer. Solution: unlock any locked parent layers.
       if (objectIsLocked(thisFrame)) {
+        var parent = thisFrame.parent;
+        var lockedAncestors = [];
+        while (parent && parent.typename != 'Document') {
+          if (parent.locked) {
+            lockedAncestors.unshift(parent);
+          }
+          parent = parent.parent;
+        }
+        forEach(lockedAncestors, unlockObject);
         unlockObject(thisFrame);
       }
       hideTextFrame(thisFrame);
@@ -2236,14 +2245,6 @@ function objectIsLocked(obj) {
     obj = obj.parent;
   }
   return false;
-}
-
-function unlockObject(obj) {
-  // unlock parent first, to avoid "cannot be modified" error
-  if (obj && obj.typename != "Document") {
-    unlockObject(obj.parent);
-    obj.locked = false;
-  }
 }
 
 function getComputedOpacity(obj) {


### PR DESCRIPTION
### Issue
The script contains duplicate definitions for the `unlockObject()` function:
- [The first one](https://github.com/newsdev/ai2html/blob/c73437878fcd6b8f2335ea2edf3b5e21ab757513/ai2html.js#L1266) is not recursive, but saves each locked object in an array to be relocked at the end of the script;
- [The second one](https://github.com/newsdev/ai2html/blob/c73437878fcd6b8f2335ea2edf3b5e21ab757513/ai2html.js#L2241) is recursive, but doesn’t save the locked state, and **it supersedes the first one**.

As a result, unlocked layers and groups are not relocked when the script finishes running.

The second definition was [introduced in version 0.115.2](https://github.com/newsdev/ai2html/commit/825c68ea373b59d63b4974f4d3f6e65acb089624) in order to fix a rare error that occurred when the script attempts to hide special text blocks (`ai2html-settings`, `ai2html-css`) overlapping artboards, if one of their ancestors is locked. Parsing of special text blocks happens before layers and groups are unlocked.

### Proposed fix
- Remove the second definition, so that locked layers/groups are properly saved and restored; the function doesn’t need to be recursive, as the `unlockContainer()` function already recursively [unlocks all sublayers and descendant groups](https://github.com/newsdev/ai2html/blob/c73437878fcd6b8f2335ea2edf3b5e21ab757513/ai2html.js#L1296), and it is called on all top-level layers;
- Recursively unlock ancestors in [the code that checks overlapping special text blocks](https://github.com/newsdev/ai2html/blob/c73437878fcd6b8f2335ea2edf3b5e21ab757513/ai2html.js#L1459) to prevent the aforementioned error.