### PR TITLE
Fix: Text burning issue

### DIFF
--- a/ai2html.js
+++ b/ai2html.js
@@ -3607,9 +3607,12 @@ function convertArtItems(activeArtboard, textFrames, masks, settings) {
 
   checkForOutputFolder(getImageFolder(settings), 'image_output_path');
 
+  var savedTextFrameState = []; 
   if (hideTextFrames) {
     for (i=0; i<textFrameCount; i++) {
-      textFrames[i].hidden = true;
+      savedTextFrameState.push([textFrames[i], textFrames[i].opacity]);
+      textFrames[i].opacity = 0;
+    }
     }
   }
 
@@ -3668,7 +3671,7 @@ function convertArtItems(activeArtboard, textFrames, masks, settings) {
   // unhide text frames
   if (hideTextFrames) {
     for (i=0; i<textFrameCount; i++) {
-      textFrames[i].hidden = false;
+      textFrames[i].opacity = savedTextFrameState[i][1];
     }
   }
 


### PR DESCRIPTION
### Issue
Sometimes, randomly and intermittently, text frames are not only exported in the HTML output, but are also burned into the image outputs, resulting in texts that appear visually duplicated (see #150). 

The issue seems to arise from some non-deterministic race condition with certain (often large) AI documents, where the `hidden` property is not properly applied before images are exported.

### Proposed fix
A solution would be to hide text frames by setting their opacity to 0, rather than using the flawed `hidden` property. As semi-transparent texts are supported, the original opacity is saved and restored after image outputs have been generated.

### Potential concerns & caveats
- This code doesn’t run if the `render_text_as: image` setting is used, so no worries here.
- Restoring the opacity to 100 might have caused problems with semi-transparent texts, but the proposed implementation restores the original opacity. HTML/CSS conversion happens before output images are generated, so we’re also safe here.
- Image exports might take slightly longer, as Illustrator theoretically needs to rasterise texts with 0% opacity, but in practice that shouldn’t be a problem unless there are thousands of text labels, and Illustrator might even be able to detect fully-transparent items and ignore them altogether.

